### PR TITLE
fix: resolve name collision and path issue for downstream Zig consumers

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -4,24 +4,10 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
-    const lib = b.addLibrary(.{
-        .linkage = .static,
-        .name = "garlic",
-        .root_module = b.createModule(.{
-            .target = target,
-            .optimize = optimize,
-            .link_libc = true,
-        }),
-    });
-
-    const exe = b.addExecutable(.{
-        .name = "garlic",
-        .root_module = b.createModule(.{
-            .target = target,
-            .optimize = optimize,
-            .link_libc = true,
-        }),
-    });
+    if (target.result.abi == .msvc) {
+        std.log.err("MSVC ABI is not supported", .{});
+        std.process.exit(1);
+    }
 
     const include_dirs = [_][]const u8{
         "src",
@@ -37,10 +23,6 @@ pub fn build(b: *std.Build) void {
         "src/jar",
         "src/dalvik",
     };
-    for (include_dirs) |dir| {
-        lib.root_module.addIncludePath(b.path(dir));
-        exe.root_module.addIncludePath(b.path(dir));
-    }
 
     var c_flags_list = std.ArrayList([]const u8).empty;
     defer c_flags_list.deinit(b.allocator);
@@ -48,10 +30,6 @@ pub fn build(b: *std.Build) void {
     c_flags_list.appendSlice(b.allocator, &.{
         "-std=c99",
         "-Wall",
-        "-Wno-unused-variable",
-        "-Wno-unused-function",
-        "-Wno-unused-parameter",
-        "-Wno-unused-but-set-variable",
         "-Wno-implicit-function-declaration",
         "-Wno-incompatible-pointer-types",
         "-Wno-misleading-indentation",
@@ -61,13 +39,10 @@ pub fn build(b: *std.Build) void {
     if (target.result.os.tag == .linux) {
         c_flags_list.appendSlice(b.allocator, &.{
             "-D_GNU_SOURCE",
-            "-flto",
-            "-Wno-ignored-optimization-argument",
         }) catch @panic("OOM");
     }
 
-    const dir = std.Io.Dir.cwd();
-    var src_dir = dir.openDir(b.graph.io, "src", .{ .iterate = true }) catch |err| {
+    var src_dir = b.build_root.handle.openDir(b.graph.io, "src", .{ .iterate = true }) catch |err| {
         std.debug.panic("unable to open src directory: {}", .{err});
     };
     defer src_dir.close(b.graph.io);
@@ -76,29 +51,67 @@ pub fn build(b: *std.Build) void {
     defer walker.deinit();
 
     var lib_c_files: std.ArrayList([]const u8) = .empty;
+    defer lib_c_files.deinit(b.allocator);
+
     while (walker.next(b.graph.io) catch @panic("walk failed")) |entry| {
         if (entry.kind == .file and std.mem.endsWith(u8, entry.basename, ".c")) {
-            const path = b.allocator.dupe(u8, entry.path) catch @panic("OOM");
+            const path = b.graph.arena.dupe(u8, entry.path) catch @panic("OOM");
             if (!std.mem.eql(u8, entry.basename, "garlic.c")) {
                 lib_c_files.append(b.allocator, path) catch @panic("OOM");
             }
         }
     }
 
+    const lib = b.addLibrary(.{
+        .linkage = .static,
+        .name = "garlic",
+        .root_module = b.createModule(.{
+            .target = target,
+            .optimize = optimize,
+            .link_libc = true,
+        }),
+    });
+
+    const exe = b.addExecutable(.{
+        .name = "garlic-cli",
+        .root_module = b.createModule(.{
+            .target = target,
+            .optimize = optimize,
+            .link_libc = true,
+        }),
+    });
+
+    for (include_dirs) |dir| {
+        lib.root_module.addIncludePath(b.path(dir));
+        exe.root_module.addIncludePath(b.path(dir));
+    }
+
     lib.root_module.addCSourceFiles(.{
         .root = b.path("src"),
+        .language = .c,
         .flags = c_flags_list.items,
         .files = lib_c_files.items,
     });
 
     exe.root_module.addCSourceFiles(.{
         .root = b.path("src"),
+        .language = .c,
         .flags = c_flags_list.items,
         .files = &.{
             "garlic.c",
         },
     });
+
     exe.root_module.linkLibrary(lib);
+
+    if (optimize != .Debug) {
+        lib.root_module.strip = true;
+        exe.root_module.strip = true;
+
+        if (!target.result.os.tag.isDarwin()) {
+            lib.lto = .full;
+        }
+    }
 
     if (target.result.os.tag == .windows) {
         exe.root_module.linkSystemLibrary("ws2_32", .{});


### PR DESCRIPTION
- Rename exe garlic → garlic-cli to avoid name collision with libgarlic, which caused ambiguity when other Zig projects link using linkLibrary
- Use b.build_root.handle.openDir instead of std.Io.Dir.cwd().openDir so source discovery works from the importing project's build root