### PR TITLE
fix(mcp): duckdb string-literal quoting and missing-duckdb detection (#82)

### DIFF
--- a/src/ai/jd_mcp_tools.c
+++ b/src/ai/jd_mcp_tools.c
@@ -327,6 +327,10 @@ static char* tool_cg_import(const char *cg_dir, const char *db_path)
         return strdup("err: call graph code not found");
     }
 
+    if (system("command -v duckdb >/dev/null 2>&1") != 0)
+        return strdup("err: duckdb not found on PATH — install it and ensure "
+                      "it is on PATH (e.g. Homebrew's /opt/homebrew/bin)");
+
     char cmd[16384];
     int n = snprintf(cmd, sizeof(cmd),
         "duckdb '%s' 2>&1 << 'DUCKEOF'\n"
@@ -372,18 +376,15 @@ static char* tool_cg_query(const char *db_path, const char *sql)
     if (access(db_path, F_OK) != 0)
         return strdup("err: database file not found");
 
-    char escaped_sql[16384];
-    size_t j = 0;
-    for (size_t i = 0; sql[i] && j < sizeof(escaped_sql) - 1; i++) {
-        if (sql[i] == '\'') escaped_sql[j++] = '\'';
-        escaped_sql[j++] = sql[i];
-    }
-    escaped_sql[j] = '\0';
-
+    /* Pass SQL via a quoted heredoc (as tool_cg_import does) so the shell
+     * performs no expansion or quote processing on it — avoids the
+     * single-quote-in-double-quote collapse entirely. */
     char cmd[16512];
     snprintf(cmd, sizeof(cmd),
-        "duckdb -readonly -csv '%s' \"%s\" 2>/dev/null",
-        db_path, escaped_sql);
+        "duckdb -readonly -csv '%s' 2>/dev/null << 'DUCKEOF'\n"
+        "%s\n"
+        "DUCKEOF",
+        db_path, sql);
 
     char *out = exec_and_capture("%s", cmd);
     if (!out) return strdup("(no results)");
@@ -413,11 +414,11 @@ static char* tool_analyze(const char *path, const char *out_dir)
     snprintf(edge_csv, sizeof(edge_csv), "%s/call_graph_edge.csv", cg_dir);
     if (access(node_csv, F_OK) == 0 && access(edge_csv, F_OK) == 0) {
         char *import_result = tool_cg_import(cg_dir, db_path);
-        if (import_result && strncmp(import_result, "err:", 4) == 0) {
-            free(import_result);
-            return strdup("err: duckdb import failed");
-        }
+        if (import_result && strncmp(import_result, "err:", 4) == 0)
+            return import_result;   /* propagate the real reason (e.g. "not on PATH") */
         free(import_result);
+        if (access(db_path, F_OK) != 0)
+            return strdup("err: duckdb import produced no database file");
     }
 
     char result[16384];


### PR DESCRIPTION
Fixes both bugs reported in #82, in the `-m` MCP server's DuckDB path (`src/ai/jd_mcp_tools.c`). No APK needed to reproduce either — both are shell-path bugs independent of any input binary.

## 1. `cg_query` silently drops single-quoted string literals

SQL was interpolated inside `"..."` while single quotes were doubled (`'`→`''`) — the escape for *inside a single-quoted SQL string*, not a double-quoted shell word — so `'hello'` became `''hello''` and collapsed to empty. This fix passes SQL via a quoted `<< 'DUCKEOF'` heredoc (the same pattern `tool_cg_import` already uses), removing shell quoting from the path entirely. Bonus: shell metacharacters in a literal (`$(...)`, backticks) no longer expand.

## 2. `analyze` reports success when `duckdb` is absent

Bare `duckdb … 2>&1` prints `duckdb: command not found` to **stdout** when the binary isn't on PATH, which `exec_and_capture` returned as non-empty, non-`err:` text — so `analyze` reported "Analysis complete" with no `.duckdb` written. This fix:
- detects `duckdb` up front (`command -v`) and returns a clear `err:` message,
- propagates the real error reason to the caller instead of a generic `"err: duckdb import failed"`,
- verifies the `.duckdb` file was actually written before reporting success.

## Verification

Built and smoke-tested against `main` + duckdb 1.5.4 on macOS/arm64: clean CMake build, no new warnings on `jd_mcp_tools.c`. Fix 1 — old form returns empty, heredoc form returns `1`; `LIKE`/quoted-identifier/apostrophe-literal queries all pass. Fix 2 — `command -v` detects present/absent correctly, and the original stdout-swallow failure mode is reproduced and resolved.

Portability note: `command -v` is POSIX shell — on the `_WIN32` path `where duckdb >nul 2>&1` would be the equivalent.

Closes #82.