### PR TITLE
fix: resolve dex field type descriptor

### DIFF
--- a/src/dalvik/dex_meta_helper.h
+++ b/src/dalvik/dex_meta_helper.h
@@ -47,9 +47,9 @@ static inline string dex_method_class_descriptor(jd_meta_dex *meta,
 
 static inline string dex_field_desc(jd_meta_dex *meta, encoded_field *efield)
 {
-    // field's class desc
+    // field's type descriptor
     dex_field_id *field_id = &meta->field_ids[efield->field_id];
-    dex_type_id *type_id = &meta->type_ids[field_id->class_idx];
+    dex_type_id *type_id = &meta->type_ids[field_id->type_idx];
     return meta->strings[type_id->descriptor_idx].data;
 }
 


### PR DESCRIPTION
修复 DEX 字段类型解析错误：

问题：dex_field_desc 错误使用 class_idx，导致字段类型被识别为所属类。
修复：改用正确的 type_idx。
修复前：

final public static StaticFields test07_public_static_final_string;

修复后：

final public static String test07_public_static_final_string;

同时 byte、int、Object 等字段类型也恢复正确。

[staticfields.dex.zip](https://github.com/user-attachments/files/30797019/staticfields.dex.zip)
